### PR TITLE
Version-Safe huduobject unwrapping for newer hudu versions

### DIFF
--- a/helpers/confluence.ps1
+++ b/helpers/confluence.ps1
@@ -176,8 +176,10 @@ function New-HuduStubArticle {
     if ($CompanyId -ne $null -and $CompanyId -ne -1) {
         $params.CompanyId = $CompanyId
     }
+    $stub = (New-HuduArticle @params)
+    $stub = $stub.article ?? $stub
 
-    return (New-HuduArticle @params).article
+    return $stub
 }
 
 


### PR DESCRIPTION
unwrapping articles, uploads, public photos that is safe for both the older hudu versions that this was first designed for and newer hudu versions that may be used now