### PR TITLE
video embed for local upload had pointed to legacy id instead of slug…

### DIFF
--- a/Confluence-Migration.ps1
+++ b/Confluence-Migration.ps1
@@ -380,16 +380,25 @@ foreach ($page in $StubbedPages) {
                     $upload = $upload.upload ?? $upload
                 }
                 write-host "$($upload.slug)"
+                $uploadFileRef = if (-not [string]::IsNullOrWhiteSpace($upload.slug)) { $upload.slug } else { $upload.id }
+                $huduUploadUrl = if ($true -eq $record.IsImage) {
+                    $upload.url
+                } else {
+                    "$HuduBaseUrl/file/$uploadFileRef"
+                }
                 $AllNewLinks.Add([PSCustomObject]@{
                     PageId        = $page.id
                     PageTitle     = $page.title
                     LocalFile     = $record.FileName
-                    HuduUrl       = $upload.url
+                    HuduUrl       = $huduUploadUrl
                     HuduUploadId  = $upload.id
+                    HuduUploadSlug= $upload.slug
                 })
                 $normalizedFileName = $record.FileName.ToLowerInvariant()
                 $ImageMap[$normalizedFileName] = @{
                   Id   = $upload.id
+                  Slug = $upload.slug
+                  Url  = $huduUploadUrl
                   Type = if ($true -eq $record.IsImage) { 'image' } else { 'upload' }
                 }
 
@@ -455,9 +464,11 @@ foreach ($page in $StubbedPages) {
         Set-Content -Path $htmlPath -Value $($page.updatedHtml) -Encoding UTF8
 
         $htmlAttachment = New-HuduUpload -FilePath $htmlPath -record_id $($page.stub).id -record_type 'Article'
+        $htmlAttachment = $htmlAttachment.upload ?? $htmlAttachment
         # $AllNewLinks+=$htmlAttachment.url
 
-        $FinalContents = "Full content too long. See attached file: <a href='$HuduBaseUrl/file/$($htmlAttachment.id)'>$($page.title).html</a>"
+        $htmlAttachmentFileRef = if (-not [string]::IsNullOrWhiteSpace($htmlAttachment.slug)) { $htmlAttachment.slug } else { $htmlAttachment.id }
+        $FinalContents = "Full content too long. See attached file: <a href='$HuduBaseUrl/file/$htmlAttachmentFileRef'>$($page.title).html</a>"
     } else {
         $FinalContents=$($($page.updatedHtml) ?? "unknown contents")
     }

--- a/helpers/confluence.ps1
+++ b/helpers/confluence.ps1
@@ -462,6 +462,16 @@ function Convert-ConfluenceHtml {
         return [System.Net.WebUtility]::HtmlDecode($Text)
     }
 
+    function Get-HuduAttachmentReference {
+        param([object]$MapEntry)
+
+        if ($MapEntry.Type -eq 'upload' -and -not [string]::IsNullOrWhiteSpace($MapEntry.Slug)) {
+            return $MapEntry.Slug
+        }
+
+        return $MapEntry.Id
+    }
+
     function Get-YouTubeEmbedUrl {
         param([string]$Url)
 
@@ -509,7 +519,7 @@ function Convert-ConfluenceHtml {
         }
 
         $mapEntry = $ImageMap[$key]
-        $id = $mapEntry.Id
+        $id = Get-HuduAttachmentReference -MapEntry $mapEntry
         $type = $mapEntry.Type
 
         $publicPhotoUrl = "$HuduBaseUrl/public_photo/$id"
@@ -601,7 +611,7 @@ function Convert-ConfluenceHtml {
 
             if ($ImageMap.ContainsKey($key)) {
                 $mapEntry = $ImageMap[$key]
-                $id = $mapEntry.Id
+                $id = Get-HuduAttachmentReference -MapEntry $mapEntry
                 $path = if ($mapEntry.Type -eq 'image') { 'public_photo' } else { 'file' }
                 return "<a href='$HuduBaseUrl/$path/$id'>$(Get-HtmlEncoded $filename)</a>"
             }


### PR DESCRIPTION
Quick link fix for upload file reference on hudu-side (id linking for uploads isnt available any longer)
<img width="1001" height="511" alt="image" src="https://github.com/user-attachments/assets/bf348b05-64e2-4de2-ad5d-0137c638dc22" />

I noticed this afterwards while checking local file video embed